### PR TITLE
Upgrade to v0.8.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**Shipped version:** 0.8.5~ynh1
+**Shipped version:** 0.8.5.3~ynh1
 
 **Demo:** <https://demo.kavitareader.com/>
 

--- a/README_es.md
+++ b/README_es.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**Versión actual:** 0.8.5~ynh1
+**Versión actual:** 0.8.5.3~ynh1
 
 **Demo:** <https://demo.kavitareader.com/>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**Paketatutako bertsioa:** 0.8.5~ynh1
+**Paketatutako bertsioa:** 0.8.5.3~ynh1
 
 **Demoa:** <https://demo.kavitareader.com/>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -32,7 +32,7 @@ Kavita est un serveur de lecture multiplateforme rapide et riche en fonctionnali
 - Analyses de bibliothèque rapides et efficaces. N'effectuez pas d'E/S si le fichier sous-jacent n'a pas changé.
 - Prise en charge OPDS-PS
 
-**Version incluse :** 0.8.5~ynh1
+**Version incluse :** 0.8.5.3~ynh1
 
 **Démo :** <https://demo.kavitareader.com/>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**Versión proporcionada:** 0.8.5~ynh1
+**Versión proporcionada:** 0.8.5.3~ynh1
 
 **Demo:** <https://demo.kavitareader.com/>
 

--- a/README_id.md
+++ b/README_id.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**Versi terkirim:** 0.8.5~ynh1
+**Versi terkirim:** 0.8.5.3~ynh1
 
 **Demo:** <https://demo.kavitareader.com/>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**Geleverde versie:** 0.8.5~ynh1
+**Geleverde versie:** 0.8.5.3~ynh1
 
 **Demo:** <https://demo.kavitareader.com/>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**Dostarczona wersja:** 0.8.5~ynh1
+**Dostarczona wersja:** 0.8.5.3~ynh1
 
 **Demo:** <https://demo.kavitareader.com/>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**Поставляемая версия:** 0.8.5~ynh1
+**Поставляемая версия:** 0.8.5.3~ynh1
 
 **Демо-версия:** <https://demo.kavitareader.com/>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -33,7 +33,7 @@ Kavita is a fast, feature rich, cross platform reading server. Built with a focu
 - OPDS-PS Support
 
 
-**分发版本：** 0.8.5~ynh1
+**分发版本：** 0.8.5.3~ynh1
 
 **演示：** <https://demo.kavitareader.com/>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Kavita"
 description.en = "Media server for your comics, manga and books"
 description.fr = "Serveur multimédia pour vos bandes dessinées, mangas et livres"
 
-version = "0.8.5~ynh1"
+version = "0.8.5.3~ynh1"
 
 maintainers = []
 
@@ -49,12 +49,12 @@ ram.runtime = "50M"
 
     [resources.sources.main]
     in_subdir = true
-    amd64.url = "https://github.com/Kareadita/Kavita/releases/download/v0.8.5/kavita-linux-x64.tar.gz"
-    amd64.sha256 = "5e196f2117f3668c3bfd5069b2775d2799cfa4f9cc62530c67464ef844f86119"
-    arm64.url = "https://github.com/Kareadita/Kavita/releases/download/v0.8.5/kavita-linux-arm64.tar.gz"
-    arm64.sha256 = "8c207a9b4f5fd70b6cb10f656d0c8b6edc8a80eba702f4fbbb00c9a0dbbf7c08"
-    armhf.url = "https://github.com/Kareadita/Kavita/releases/download/v0.8.5/kavita-linux-arm.tar.gz"
-    armhf.sha256 = "50b93a206883182a7052c08ea010d580673f155a7eab8856c8f4b9e9335160ce"
+    amd64.url = "https://github.com/Kareadita/Kavita/releases/download/v0.8.5.3/kavita-linux-x64.tar.gz"
+    amd64.sha256 = "847ca9ae6f54c9da32133729f791477bb43b1456a57ab4ca68a1ea6f9f62c335"
+    arm64.url = "https://github.com/Kareadita/Kavita/releases/download/v0.8.5.3/kavita-linux-arm64.tar.gz"
+    arm64.sha256 = "fb4555761ce8019784250a3062714326c1c5103944fafcd5eba3fb9adc7b6451"
+    armhf.url = "https://github.com/Kareadita/Kavita/releases/download/v0.8.5.3/kavita-linux-arm.tar.gz"
+    armhf.sha256 = "5f8dfb86adca596ad5bba7e6c852ca7daf762a2b58dc7f3e8349d79036e65c2f"
 
     # https://yunohost.org/fr/packaging_apps_resources#regarding-autoupdate
     autoupdate.strategy = "latest_github_release"


### PR DESCRIPTION
Upgrade sources
- `main` v0.8.5.3: https://github.com/Kareadita/Kavita/releases/tag/v0.8.5.3

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on <https://ci-apps-dev.yunohost.org/> *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
